### PR TITLE
fix typo & fix include

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: postgres
 
-Install & create postgress database on Debian GNU/Linux.
+Install & create PostgreSQL database on Debian GNU/Linux.
 
 ## Requirements
 The role is designed for [Debian GNU/Linux](https://debian.org).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: install and configure postgres
   include: postgres.yml
   tags:
-    - postgress
+    - postgres
 
 # this causes postgres (and any other handler) to restart
 - name: flush handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
     - ssh
 
 - name: install and configure postgres
-  include: postgres.yml
+  include_tasks: postgres.yml
   tags:
     - postgres
 

--- a/tasks/postgres.yml
+++ b/tasks/postgres.yml
@@ -4,7 +4,7 @@
   apt:
     name:
       - gpg # needed for ansible.builtin.apt_key
-      - python3-psycopg2 # needed for ansible postgress modules
+      - python3-psycopg2 # needed for ansible postgres modules
     state: latest
     cache_valid_time: 86400
   tags:
@@ -63,7 +63,7 @@
   tags:
     - postgres_check4other
 
-- name: filterout all installed postgress versions
+- name: filterout all installed postgres versions
   set_fact:
     postgres_packages: "{{ ansible_facts.packages | dict2items | selectattr('key', 'match', '^postgresql-[0-9]+$') | map(attribute='key') | list }}"
   tags:
@@ -83,7 +83,7 @@
   apt:
     name:
       - "{{ postgres_package }}"
-      - python3-psycopg2 # needed for ansible postgress modules
+      - python3-psycopg2 # needed for ansible postgres modules
     state: latest
     cache_valid_time: 86400
   tags:
@@ -117,7 +117,7 @@
     create: true
   tags:
     - postgres_pg_hba
-    - postgress_czertainly_remote_access
+    - postgres_czertainly_remote_access
   notify:
     restart postgresql
 
@@ -127,7 +127,7 @@
   community.postgresql.postgresql_db:
     name: "{{ postgres.database | default('czertainlydb') }}"
   tags:
-    - postgress_czertainly_db
+    - postgres_czertainly_db
 
 - name: create czertainlyuser
   become: yes
@@ -138,7 +138,7 @@
     password: "{{ postgres.password | default('your-strong-password') }}"
   when: not ansible_check_mode # will fail in check mode if db isn't present
   tags:
-    - postgress_czertainly_user
+    - postgres_czertainly_user
 
 - name: grant ALL priv to czertainlydb to czertainlyuser
   become: yes
@@ -151,4 +151,4 @@
     role: "{{ postgres.username | default('czertainlyuser') }}"
   when: not ansible_check_mode # will fail in check mode if db isn't present
   tags:
-    - postgress_czertainly_grant_all
+    - postgres_czertainly_grant_all


### PR DESCRIPTION
fix my common typo postgress - closes https://github.com/3KeyCompany/ansible-role-postgres/issues/17
start using include_tast instead of include to get rid of obsolete warning in Ansible